### PR TITLE
Replace OkHttp with java Http

### DIFF
--- a/src/main/java/com/github/instagram4j/instagram4j/requests/IGGetRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/IGGetRequest.java
@@ -5,12 +5,14 @@ import com.github.instagram4j.instagram4j.responses.IGResponse;
 
 import okhttp3.Request;
 
+import java.net.http.HttpRequest;
+
 public abstract class IGGetRequest<T extends IGResponse> extends IGRequest<T> {
 
     @Override
-    public Request formRequest(IGClient client) {
-        Request.Builder req = new Request.Builder()
-                .url(this.formUrl(client));
+    public HttpRequest formRequest(IGClient client) {
+        HttpRequest.Builder req = HttpRequest.newBuilder()
+                .uri(this.formUri(client));
         this.applyHeaders(client, req);
 
         return req.build();

--- a/src/main/java/com/github/instagram4j/instagram4j/requests/IGPostRequest.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/requests/IGPostRequest.java
@@ -11,6 +11,8 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
+import java.net.http.HttpRequest;
+
 @Slf4j
 public abstract class IGPostRequest<T extends IGResponse> extends IGRequest<T> {
 
@@ -21,10 +23,11 @@ public abstract class IGPostRequest<T extends IGResponse> extends IGRequest<T> {
     }
 
     @Override
-    public Request formRequest(IGClient client) {
-        Request.Builder req = new Request.Builder().url(this.formUrl(client));
+    public HttpRequest formRequest(IGClient client) {
+        HttpRequest.Builder req = HttpRequest.newBuilder().uri(this.formUri(client));
         this.applyHeaders(client, req);
-        req.post(this.getRequestBody(client));
+        //FIXME
+        req.POST(this.getRequestBody(client));
 
         return req.build();
     }

--- a/src/main/java/com/github/instagram4j/instagram4j/utils/IGUtils.java
+++ b/src/main/java/com/github/instagram4j/instagram4j/utils/IGUtils.java
@@ -218,7 +218,7 @@ public class IGUtils {
     }
 
     public static HttpClient.Builder defaultHttpClientBuilder() {
-        return HttpClient.newBuilder().cookieHandler(new CookieManager());
+        return HttpClient.newBuilder().CookieManager(new CookieManager());
     }
 
     public static String randomUuid() {
@@ -242,15 +242,23 @@ public class IGUtils {
         return MAPPER.convertValue(o, type);
     }
 
-    public static Optional<String> getCookieValue(CookieJar jar, String key) {
+    public static Optional<String> getCookieValue(CookieStore cookies, String key) {
         try {
-            return jar.loadForRequest(new URL(IGConstants.BASE_API_URL)).stream()
-                    .filter(cookie -> cookie.name().equals(key)).map(Cookie::value).findAny();
-        } catch (MalformedURLException e) {
+            return cookies.get(new URI(IGConstants.BASE_API_URL)).stream()
+                    .filter(cookie -> cookie.getName().equals(key)).map(HttpCookie::getValue).findAny();
+        } catch (URISyntaxException e) {
             throw new AssertionError("Base API URL is invalid", e);
         }
     }
 
+    public static CookieStore getCookieStore(HttpClient client) {
+        //TODO extract cookie store in a better way
+        return  client.cookieHandler()
+                .filter(CookieManager.class::isInstance)
+                .map(CookieManager.class::cast)
+                .map(CookieManager::getCookieStore)
+                .orElseThrow();
+    }
     public static String truncate(String s) {
         return s != null ? s.substring(0, Math.min(100, s.length())) : s;
     }

--- a/src/test/java/instagram4j/RequestTest.java
+++ b/src/test/java/instagram4j/RequestTest.java
@@ -9,6 +9,8 @@ import com.github.instagram4j.instagram4j.responses.IGResponse;
 
 import okhttp3.Request;
 
+import java.net.http.HttpRequest;
+
 public class RequestTest {
     private class IGTestRequest extends IGRequest<IGResponse> {
         @Override
@@ -17,7 +19,7 @@ public class RequestTest {
         }
 
         @Override
-        public Request formRequest(IGClient client) {
+        public HttpRequest formRequest(IGClient client) {
             // dummy
             return null;
         }
@@ -33,6 +35,6 @@ public class RequestTest {
     public void testUrlFormation() {
         IGTestRequest test = new IGTestRequest();
         Assert.assertEquals("https://i.instagram.com/api/v1/test/path/",
-                test.formUrl(null).toString());
+                test.formUri(null).toString());
     }
 }


### PR DESCRIPTION
Fixes #4 

One issue I am facing is the entire `CookieJar` system throughout the IG API, java http does not have a straightforward replacement to that class, and we might have to make a few utility classes to create support for the OkHttp cookie handling system